### PR TITLE
minor: relaxing the version regex

### DIFF
--- a/bin/m
+++ b/bin/m
@@ -114,11 +114,10 @@ display_m_version() {
 #
 # Check for installed version, and populate $active
 #
-
 check_current_version() {
   which mongo &> /dev/null
   if test $? -eq 0; then
-    active=`mongod --version | egrep -o '[0-9]+\.[0-9]+\.[0-9]+([-_\.]rc[0-9]{1})?'`
+    active=`mongod --version | egrep -o '[0-9]+\.[0-9]+\.[0-9]+([-_\.][a-zA-Z0-9]+)$'`
   fi
 }
 


### PR DESCRIPTION
This patch updates the version regex to be a little less restrictive and play
nicer with custom build names. For example, I have a custom build for MongoDB
'2.4.6-sub' that doesn't match the current regex due to its requirement for
'rc' in the name.

The new regex would match all of the following examples:

2.4.6-sub
2.4.6-rc999
2.4.6.custom
2.4.6-anythinguntilendofline

This will give us a little more flexibility in naming and identifying custom
server versions under m.
