### PR TITLE
minor: fixing my mistake in version regex

### DIFF
--- a/bin/m
+++ b/bin/m
@@ -117,7 +117,7 @@ display_m_version() {
 check_current_version() {
   which mongo &> /dev/null
   if test $? -eq 0; then
-    active=`mongod --version | egrep -o '[0-9]+\.[0-9]+\.[0-9]+([-_\.][a-zA-Z0-9]+)$'`
+    active=`mongod --version | egrep -o '[0-9]+\.[0-9]+\.[0-9]+([-_\.][a-zA-Z0-9]+)?'`
   fi
 }
 


### PR DESCRIPTION
I made a mistake in my previous change and it doesn't quite match 2.2.x versions correct. Removing this EOL matcher resolves issues with older build versions.

Match examples:
http://rubular.com/r/udn4cHOICI
