### PR TITLE
Sort versions properly

### DIFF
--- a/bin/m
+++ b/bin/m
@@ -128,8 +128,9 @@ check_current_version() {
 
 display_versions() {
   check_current_version
-  for dir in $VERSIONS_DIR/*; do
-    local version=${dir##*/}
+  local versions=`ls -1 $VERSIONS_DIR | sort -t. -k 1,1n -k 2,2n -k 3,3n`
+  for version in $versions; do
+    local dir="$VERSIONS_DIR/$version"
     local config=`test -f $dir/.config && cat $dir/.config`
     if test "$version" = "$active"; then
       printf "  \033[32mο\033[0m $version \033[90m$config\033[0m\n"


### PR DESCRIPTION
From this:

```
$ m
    1.8.5
    2.0.7
    2.0.9
    2.2.1
    2.2.3
    2.2.4
    2.2.5
    2.2.6
    2.2.7
    2.4.1
    2.4.10
    2.4.11
    2.4.12
    2.4.3
    2.4.4
    2.4.5
    2.4.6
    2.4.7
    2.4.8
    2.4.9
    2.6.0
    2.6.1
    2.6.2
    2.6.3
    2.6.4
    2.6.5
    2.7.8
  ο 2.8.0-rc0
```

to this:

```
$ m
    1.8.5
    2.0.7
    2.0.9
    2.2.1
    2.2.3
    2.2.4
    2.2.5
    2.2.6
    2.2.7
    2.4.1
    2.4.3
    2.4.4
    2.4.5
    2.4.6
    2.4.7
    2.4.8
    2.4.9
    2.4.10
    2.4.11
    2.4.12
    2.6.0
    2.6.1
    2.6.2
    2.6.3
    2.6.4
    2.6.5
    2.7.8
  ο 2.8.0-rc0
```
