### PR TITLE
Fixed check_current_version to display version 3.2.7 with OpenSSL correctly

### DIFF
--- a/bin/m
+++ b/bin/m
@@ -119,7 +119,7 @@ display_m_version() {
 check_current_version() {
   which mongo &> /dev/null
   if test $? -eq 0; then
-    active=`mongod --version | egrep -o '[0-9]+\.[0-9]+\.[0-9]+([-_\.][a-zA-Z0-9]+)?'`
+    active=`mongod --version | egrep -o '[0-9]+\.[0-9]+\.[0-9]+([-_\.][a-zA-Z0-9]+)?' | head -1`
   fi
 }
 


### PR DESCRIPTION
check_current_version does not capture the version number of MongoDB 3.2.7 correctly (OSX, OpenSSL version) due to the regex capturing the OpenSSL version instead. This patch should fix it.