### PR TITLE
Generalize cp for BSD+GNU

### DIFF
--- a/bin/m
+++ b/bin/m
@@ -161,7 +161,7 @@ install_mongo() {
   if test -d $dir; then
     pre change
     cd $dir \
-      && cp -Rf $dir/bin/ $M_PREFIX/bin \
+      && cp -Rf $dir/bin/* $M_PREFIX/bin \
       && post change
   # install
   else


### PR DESCRIPTION
The GNU cp command treats dir/ and dir as the same when using the recursive flag.
This leads to $M_PREFIX/bin/bin instead of $M_PREFIX/bin which means the intended mongo binaries are not in the path.