### PR TITLE
Avoid getcwd warning

### DIFF
--- a/bin/m
+++ b/bin/m
@@ -377,6 +377,7 @@ download() {
 
   # see if things are alright
   if test $? -gt 0; then
+    cd -
     cleanup "$builddir"
     printf "\033[31mError: installation failed\033[0m\n"
     printf "  MongoDB version $version does not exist,\n"
@@ -386,6 +387,7 @@ download() {
     printf "  error details.\n"
     exit 1
   fi
+  cd -
 }
 
 #


### PR DESCRIPTION
$builddir is being delete further down the script,
which causes warnings. It can be avoided if jump back
after downloading the package.
