### PR TITLE
Improved sort ordering of version numbers

### DIFF
--- a/bin/m
+++ b/bin/m
@@ -528,7 +528,9 @@ list_versions() {
   local versions=""
   versions=`$GET 2> /dev/null http://dl.mongodb.org/dl/src/ \
     | egrep -o '[0-9]+\.[0-9]+\.[0-9]+([-_\.]rc[0-9]+)?' \
-    | sort -u -k 1,1n -k 2,2n -k 3,3 -t . \
+    | sort -u \
+    | sort -s -k 2.3n -t - \
+    | sort -s -k 1,1n -k 2,2n -k 3,3n -t . \
     | awk '{ print "  " $1 }'`
 
   for v in $versions; do


### PR DESCRIPTION
Version numbers are currently being sorted as 3.3.0, 3.3.1, 3.3.10, 3.3.11, ..., 3.3.2, .... This fix sorts version in a more natural order of 3.3.0, 3.3.1, 3.3.2, ..., 3.3.10, 3.3.11, ...
