### PR TITLE
Handle the case of no installed versions when listing installed versions

### DIFF
--- a/bin/m
+++ b/bin/m
@@ -137,6 +137,10 @@ display_versions() {
 
   declare -a versions
   versions=(`ls -1 $VERSIONS_DIR | sort -t. -k 1,1n -k 2,2n -k 3,3n`)
+  if test -z "$versions"; then
+    echo No installed versions
+    return
+  fi
   local last=${versions[${#versions[@]}-1]}
 
   if test "$option" = "--json"; then


### PR DESCRIPTION
Prior to this, running m when there are no installed versions
produced an error message:

m: line 140: versions: bad array subscript

Now it would report that no versions are installed:

No installed versions