### PR TITLE
Default installation prompt to yes.

### DIFF
--- a/bin/m
+++ b/bin/m
@@ -205,11 +205,10 @@ install_mongo() {
 prompt_install() {
   echo $1
   while true; do
-    read -p "Installation may take a while. Would you like to proceed? [y/n] " yn
+    read -p "Installation may take a while. Would you like to proceed? [Y/n] " yn
     case $yn in
-      [Yy]* ) break;;
-      [Nn]* ) echo "Aborted."; exit 0;;
-      * ) echo "Please answer yes or no.";;
+      [Nn]* ) echo "Aborted."; exit ;;
+      * ) break;;
     esac
   done
 }


### PR DESCRIPTION
Apt (the package manager) has had this default for as long as I remember
which is many years, and if it works for an operating system's
package manager it should also work for a Mongo version manager.

Also changed the return value of m when the user answers in the
negative, as the operation fails in that scenario.

This doesn't make a difference for #27 as there is still a prompt, but makes interactive use much more pleasant.