### PR TITLE
Set -e compatibility

### DIFF
--- a/bin/m
+++ b/bin/m
@@ -122,7 +122,9 @@ check_current_version() {
   if test $? -eq 0; then
     active=`mongod --version | grep "version\s*v[0-9]" | egrep -o '[0-9]+\.[0-9]+\.[0-9]+([-_\.][a-zA-Z0-9]+)?' | head -1`
     ent=`mongod --version | egrep "modules:\s*enterprise" | wc -l`
-    [[ $ent == *1 ]] && active="$active-ent"
+    if [[ $ent == *1 ]]; then
+      active="$active-ent"
+    fi
   fi
 }
 


### PR DESCRIPTION
This allows running m with bash -ex which is helpful for debugging.