### PR TITLE
Install linux distribution-specific versions

### DIFF
--- a/bin/m
+++ b/bin/m
@@ -315,6 +315,44 @@ install_bin() {
     sslbuild=$os
   fi
 
+  local DISTRO="`lsb_release -si`-`lsb_release -sr`"
+  local distro=`echo $DISTRO | tr '[:upper:]' '[:lower:]'`
+  # Different versions of MongoDB have builds for different distributions.
+  # As m allows installing old MongoDB versions, we can look for
+  # binaries for distributions that the latest MongoDB release is not
+  # built for. Conversely, an old MongoDB version does not have to have
+  # builds available for distributions that the latest version supports.
+  #
+  # The logic generally is to start with the correct distribution, then try
+  # one version older and one version newer. This should handle most cases
+  # reasonably well.
+  case "$distro" in
+    debian-6.*)
+      distros="debian71 debian81" ;;
+    debian-7.*)
+      distros="debian71 debian81" ;;
+    debian-8.*)
+      distros="debian81 debian71 debian92" ;;
+    debian-9.*)
+      distros="debian92 debian81 debian71" ;;
+    debian-*)
+      distros="debian92 debian81 debian71" ;;
+    
+    ubuntu-12.*)
+      distros="ubuntu1204 ubuntu1404" ;;
+    ubuntu-14.*)
+      distros="ubuntu1404 ubuntu1204 ubuntu1604" ;;
+    ubuntu-16.*)
+      distros="ubuntu1604 ubuntu1404 ubuntu1204" ;;
+    ubuntu-18.*)
+      distros="ubuntu1604 ubuntu1404 ubuntu1204" ;;
+    ubuntu-*)
+      distros="ubuntu1604 ubuntu1404 ubuntu1204" ;;
+    
+    *)
+      distros="" ;;
+  esac
+
   # determine the download url
   if [[ "$community" == 1 ]]; then
     local tarball="mongodb-$sslbuild-$arch-$version.tgz"

--- a/bin/m
+++ b/bin/m
@@ -275,7 +275,6 @@ install_bin() {
   local config=$2
   local community=1
 
-
   # check if enterprise
   if [[ $version == *-ent ]]; then
     community=0
@@ -322,7 +321,29 @@ install_bin() {
     local url="http://fastdl.mongodb.org/$os/$tarball"
   else # enterprise version
     if [[ "$os" == linux ]]; then
-      local tarball="mongodb-$os-$arch-enterprise-rhel70-$version.tgz" # for linux fetch the rhel7 tarball
+      # for linux fetch the rhel7 tarball by default
+      local dist=rhel70
+      if test -e /etc/debian_version; then
+        local debian_version=`cat /etc/debian_version`
+        case "$debian_version" in
+          wheezy* )
+            debian_versions="71"
+            ;;
+          jessie* )
+            debian_versions="81 71"
+            ;;
+          * )
+            debian_versions="92 81 71"
+            ;;
+        esac
+        for debian_version in $debian_versions; do
+          if good "http://downloads.10gen.com/$os/mongodb-$os-$arch-enterprise-debian$debian_version-$version.tgz"; then
+            dist=debian$debian_version
+            break
+          fi
+        done
+      fi
+      local tarball="mongodb-$os-$arch-enterprise-$dist-$version.tgz"
     else
       local tarball="mongodb-$os-$arch-enterprise-$version.tgz"
     fi

--- a/bin/m
+++ b/bin/m
@@ -317,7 +317,7 @@ install_bin() {
 
   local distro_id= distro_version=
   if lsb_release >/dev/null 2>&1; then
-    # Debian/Ubuntu
+    # Debian/Ubuntu, also RHEL proper but not centos
     distro_id=`lsb_release -si`
     distro_version=`lsb_release -sr`
     if test "$distro_version" = testing; then
@@ -433,26 +433,13 @@ install_bin() {
     if [[ "$os" == linux ]]; then
       # for linux fetch the rhel7 tarball by default
       local dist=rhel70
-      if test -e /etc/debian_version; then
-        local debian_version=`cat /etc/debian_version`
-        case "$debian_version" in
-          wheezy* )
-            debian_versions="71"
-            ;;
-          jessie* )
-            debian_versions="81 71"
-            ;;
-          * )
-            debian_versions="92 81 71"
-            ;;
-        esac
-        for debian_version in $debian_versions; do
-          if good "http://downloads.10gen.com/$os/mongodb-$os-$arch-enterprise-debian$debian_version-$version.tgz"; then
-            dist=debian$debian_version
-            break
-          fi
-        done
-      fi
+      # shadowing earlier $distro
+      for distro in $distros; do
+        if good "http://downloads.10gen.com/$os/mongodb-$os-$arch-enterprise-$distro-$version.tgz"; then
+          dist=$distro
+          break
+        fi
+      done
       local tarball="mongodb-$os-$arch-enterprise-$dist-$version.tgz"
     else
       local tarball="mongodb-$os-$arch-enterprise-$version.tgz"

--- a/bin/m
+++ b/bin/m
@@ -378,24 +378,24 @@ install_bin() {
   # one version older and one version newer. This should handle most cases
   # reasonably well.
   case "$distro" in
-    debian-6.*)
+    debian-6*)
       distros="debian71 debian81" ;;
-    debian-7.*)
+    debian-7*)
       distros="debian71 debian81" ;;
-    debian-8.*)
+    debian-8*)
       distros="debian81 debian71 debian92" ;;
-    debian-9.*)
+    debian-9*)
       distros="debian92 debian81 debian71" ;;
     debian-*)
       distros="debian92 debian81 debian71" ;;
     
-    ubuntu-12.*)
+    ubuntu-12*)
       distros="ubuntu1204 ubuntu1404" ;;
-    ubuntu-14.*)
+    ubuntu-14*)
       distros="ubuntu1404 ubuntu1204 ubuntu1604" ;;
-    ubuntu-16.*)
+    ubuntu-16*)
       distros="ubuntu1604 ubuntu1404 ubuntu1204" ;;
-    ubuntu-18.*)
+    ubuntu-18*)
       distros="ubuntu1604 ubuntu1404 ubuntu1204" ;;
     ubuntu-*)
       distros="ubuntu1604 ubuntu1404 ubuntu1204" ;;

--- a/bin/m
+++ b/bin/m
@@ -410,7 +410,12 @@ install_bin() {
       distros="suse12 suse11 suse10" ;;
     
     amzn-*)
-      distros="amzn64" ;;
+      if test "$community" = 1; then
+        distros=amazon
+      else
+        distros="amzn64"
+      fi
+      ;;
     
     rhel-5*)
       distros="rhel57" ;;

--- a/bin/m
+++ b/bin/m
@@ -428,6 +428,13 @@ install_bin() {
   # determine the download url
   if [[ "$community" == 1 ]]; then
     local tarball="mongodb-$sslbuild-$arch-$version.tgz"
+    # shadowing earlier $distro
+    for distro in $distros; do
+      if good "http://fastdl.mongodb.org/$os/mongodb-$sslbuild-$arch-$distro-$version.tgz"; then
+        tarball="mongodb-$sslbuild-$arch-$distro-$version.tgz"
+        break
+      fi
+    done
     local url="http://fastdl.mongodb.org/$os/$tarball"
   else # enterprise version
     if [[ "$os" == linux ]]; then

--- a/bin/m
+++ b/bin/m
@@ -315,8 +315,59 @@ install_bin() {
     sslbuild=$os
   fi
 
-  local DISTRO="`lsb_release -si`-`lsb_release -sr`"
-  local distro=`echo $DISTRO | tr '[:upper:]' '[:lower:]'`
+  local distro_id= distro_version=
+  if lsb_release >/dev/null 2>&1; then
+    # Debian/Ubuntu
+    distro_id=`lsb_release -si`
+    distro_version=`lsb_release -sr`
+    if test "$distro_version" = testing; then
+      distro_version=
+    fi
+  fi
+  if test -z "$distro_version" && test -f /etc/debian_version; then
+    # Debian without lsb_release installed, or Debian testing or sid.
+    # (We don't handle sid.)
+    # This will also catch ubuntus that don't have lsb_release installed,
+    # which is not good
+    distro_version=`cat /etc/debian_version`
+    case "$distro_version" in
+      etch*)
+        distro_version=4 ;;
+      lenny*)
+        distro_version=5 ;;
+      squeeze*)
+        distro_version=6 ;;
+      wheezy*)
+        distro_version=7 ;;
+      jessie*)
+        distro_version=8 ;;
+      stretch*)
+        distro_version=9 ;;
+      buster*)
+        distro_version=10 ;;
+      bullseye*)
+        distro_version=11 ;;
+      bookworm*)
+        distro_version=12 ;;
+    esac
+    distro_id=debian
+  elif test -f /etc/os-release; then
+    # Suse, opensuse, amazon linux, centos (but not redhat)
+    distro_id=`(. /etc/os-release && echo $ID) | tr '[:upper:]' '[:lower:]'`
+    distro_version=`(. /etc/os-release && echo $VERSION_ID)`
+  fi
+  
+  distro_id=`echo "$distro_id" | tr '[:upper:]' '[:lower:]'`
+  distro_version=`echo "$distro_version" | tr '[:upper:]' '[:lower:]'`
+  if test "$distro_id" = sles || test "$distro_id" = opensuse; then
+    distro_id=suse
+  fi
+  if test "$distro_id" = centos || test "$distro_id" = redhatenterpriseserver; then
+    distro_id=rhel
+  fi
+  
+  local distro=$distro_id:$distro_version
+  
   # Different versions of MongoDB have builds for different distributions.
   # As m allows installing old MongoDB versions, we can look for
   # binaries for distributions that the latest MongoDB release is not
@@ -348,6 +399,27 @@ install_bin() {
       distros="ubuntu1604 ubuntu1404 ubuntu1204" ;;
     ubuntu-*)
       distros="ubuntu1604 ubuntu1404 ubuntu1204" ;;
+    
+    suse-10*)
+      distros="suse10" ;;
+    suse-11*)
+      distros="suse11 suse10" ;;
+    suse-12*)
+      distros="suse12 suse11 suse10" ;;
+    suse-*)
+      distros="suse12 suse11 suse10" ;;
+    
+    amzn-*)
+      distros="amzn64" ;;
+    
+    rhel-5*)
+      distros="rhel57" ;;
+    rhel-6*)
+      distros="rhel62 rhel57" ;;
+    rhel-7*)
+      distros="rhel72 rhel71 rhel70 rhel62 rhel57" ;;
+    rhel-*)
+      distros="rhel72 rhel71 rhel70 rhel62 rhel57" ;;
     
     *)
       distros="" ;;

--- a/bin/m
+++ b/bin/m
@@ -366,7 +366,7 @@ install_bin() {
     distro_id=rhel
   fi
   
-  local distro=$distro_id:$distro_version
+  local distro=$distro_id-$distro_version
   
   # Different versions of MongoDB have builds for different distributions.
   # As m allows installing old MongoDB versions, we can look for


### PR DESCRIPTION
This is needed for enterprise server versions to reference the correct libsnmp binary, for instance.