### PR TITLE
Linux distro-specific support

### DIFF
--- a/bin/m
+++ b/bin/m
@@ -324,49 +324,55 @@ install_bin() {
       distro_version=
     fi
   fi
-  if test -z "$distro_version" && test -f /etc/debian_version; then
-    # Debian without lsb_release installed, or Debian testing or sid.
-    # (We don't handle sid.)
-    # This will also catch ubuntus that don't have lsb_release installed,
-    # which is not good
-    distro_version=`cat /etc/debian_version`
-    case "$distro_version" in
-      etch*)
-        distro_version=4 ;;
-      lenny*)
-        distro_version=5 ;;
-      squeeze*)
-        distro_version=6 ;;
-      wheezy*)
-        distro_version=7 ;;
-      jessie*)
-        distro_version=8 ;;
-      stretch*)
-        distro_version=9 ;;
-      buster*)
-        distro_version=10 ;;
-      bullseye*)
-        distro_version=11 ;;
-      bookworm*)
-        distro_version=12 ;;
-    esac
-    distro_id=debian
-  elif test -f /etc/os-release; then
-    # Suse, opensuse, amazon linux, centos (but not redhat)
-    distro_id=`(. /etc/os-release && echo $ID) | tr '[:upper:]' '[:lower:]'`
-    distro_version=`(. /etc/os-release && echo $VERSION_ID)`
+  if test -z "$distro_version"; then
+    if test -f /etc/lsb-release; then
+      # In the case where the distro provides an /etc/lsb-release file, but the lsb_release(1) util isn't installed.
+      distro_id=`sed -ne 's/^DISTRIB_ID=//p' /etc/os-release | sed -e 's/^["'"'"']//' -e 's/["'"'"']$//' -e 's/\\\(.\)/\1/g'`
+      distro_version=`sed -ne 's/^DISTRIB_RELEASE=//p' /etc/os-release | sed -e 's/^["'"'"']//' -e 's/["'"'"']$//' -e 's/\\\(.\)/\1/g'`
+    elif test -f /etc/debian_version; then
+      # Debian without lsb_release installed, or Debian testing or sid.
+      # (We don't handle sid.)
+      # This will also catch ubuntus that don't have lsb_release installed,
+      # which is not good
+      distro_version=`cat /etc/debian_version`
+      case "$distro_version" in
+        etch|etch/*)
+          distro_version=4 ;;
+        lenny|lenny/*)
+          distro_version=5 ;;
+        squeeze|squeeze/*)
+          distro_version=6 ;;
+        wheezy|wheezy/*)
+          distro_version=7 ;;
+        jessie|jessie/*)
+          distro_version=8 ;;
+        stretch|stretch/*)
+          distro_version=9 ;;
+        buster|buster/*)
+          distro_version=10 ;;
+        bullseye|bullseye/*)
+          distro_version=11 ;;
+        bookworm|bookworm/*)
+          distro_version=12 ;;
+      esac
+      distro_id=debian
+    elif test -f /etc/os-release; then
+      # Suse, opensuse, amazon linux, centos (but not redhat)
+      distro_id=`sed -ne 's/^ID=//p' /etc/os-release | sed -e 's/^["'"'"']//' -e 's/["'"'"']$//' -e 's/\\\(.\)/\1/g'`
+      distro_version=`sed -ne 's/^VERSION_ID=//p' /etc/os-release | sed -e 's/^["'"'"']//' -e 's/["'"'"']$//' -e 's/\\\(.\)/\1/g'`
+    fi
   fi
   
   distro_id=`echo "$distro_id" | tr '[:upper:]' '[:lower:]'`
   distro_version=`echo "$distro_version" | tr '[:upper:]' '[:lower:]'`
-  if test "$distro_id" = sles || test "$distro_id" = opensuse; then
-    distro_id=suse
-  fi
-  if test "$distro_id" = centos || test "$distro_id" = redhatenterpriseserver; then
-    distro_id=rhel
-  fi
+  case "$distro_id" in
+    sles) distro_id="suse" ;;
+    opensuse) distro_id="suse" ;;
+    centos) distro_id="rhel" ;;
+    redhatenterpriseserver) distro_id="rhel" ;;
+  esac
   
-  local distro=$distro_id-$distro_version
+  local distro="$distro_id-$distro_version"
   
   # Different versions of MongoDB have builds for different distributions.
   # As m allows installing old MongoDB versions, we can look for
@@ -396,9 +402,9 @@ install_bin() {
     ubuntu-16*)
       distros="ubuntu1604 ubuntu1404 ubuntu1204" ;;
     ubuntu-18*)
-      distros="ubuntu1604 ubuntu1404 ubuntu1204" ;;
+      distros="ubuntu1804 ubuntu1604 ubuntu1404 ubuntu1204" ;;
     ubuntu-*)
-      distros="ubuntu1604 ubuntu1404 ubuntu1204" ;;
+      distros="ubuntu1804 ubuntu1604 ubuntu1404 ubuntu1204" ;;
     
     suse-10*)
       distros="suse10" ;;
@@ -411,7 +417,7 @@ install_bin() {
     
     amzn-*)
       if test "$community" = 1; then
-        distros=amazon
+        distros="amazon"
       else
         distros="amzn64"
       fi

--- a/bin/m
+++ b/bin/m
@@ -52,10 +52,10 @@ fi
 GET=
 
 # wget support (Added --no-check-certificate for Github downloads)
-which wget > /dev/null && GET="wget -q -O-"
+which wget 2>&1 > /dev/null && GET="wget -q -O-"
 
 # curl support
-which curl > /dev/null && GET="curl -# -L"
+which curl 2>&1 > /dev/null && GET="curl -# -L"
 
 # Ensure we have curl or wget
 
@@ -78,6 +78,7 @@ display_help() {
     m X.Y                        Install or activate the latest patch release for MongoDB X.Y (eg. 3.6)
     m <version> [config ...]     Install and/or use MongoDB <version>
     m custom <version> <tarball> [config ...]  Install custom MongoDB <tarball> with [args ...]
+    m --legacy <version>         Install generic Linux version
     m use <version> [args ...]   Execute mongod <version> with [args ...]
     m shard <version> [args ...] Execute mongos <version> with [args ...]
     m shell <version> [args ...] Open a mongo shell <version> with [args ...]
@@ -190,15 +191,12 @@ display_versions() {
   fi
 }
 
+
 #
 # Install MongoDB <version> [config ...]
 #
 
 install_mongo() {
-  if [ "$1" -eq "--legacy" ]; then
-    _legacy_only=y
-    shift
-  fi
   local version=$1; shift
   local config=$@
   check_current_version
@@ -238,6 +236,17 @@ install_mongo() {
     prompt_install "MongoDB version $version is not installed."
     install_bin $version $config
   fi
+}
+
+#
+# Install legacy version (Linux generic version)
+#
+
+install_legacy() {
+  echo "LEGACY"
+  _legacy_only=y
+  shift
+  install_mongo $@
 }
 
 #
@@ -331,8 +340,8 @@ install_bin() {
   if test -z "$distro_version"; then
     if test -f /etc/lsb-release; then
       # In the case where the distro provides an /etc/lsb-release file, but the lsb_release(1) util isn't installed.
-      distro_id=`sed -ne 's/^DISTRIB_ID=//p' /etc/os-release | sed -e 's/^["'"'"']//' -e 's/["'"'"']$//' -e 's/\\\(.\)/\1/g'`
-      distro_version=`sed -ne 's/^DISTRIB_RELEASE=//p' /etc/os-release | sed -e 's/^["'"'"']//' -e 's/["'"'"']$//' -e 's/\\\(.\)/\1/g'`
+      distro_id=$(sed -ne 's/^DISTRIB_ID=//p' /etc/lsb-release | sed -e 's/^["'"'"']//' -e 's/["'"'"']$//' -e 's/\\\(.\)/\1/g')
+      distro_version=$(sed -ne 's/^DISTRIB_RELEASE=//p' /etc/lsb-release | sed -e 's/^["'"'"']//' -e 's/["'"'"']$//' -e 's/\\\(.\)/\1/g')
     elif test -f /etc/debian_version; then
       # Debian generally doesn't install lsb_release(1) or a /etc/lsb-release file, so we figure it out manually.
       distro_version=`cat /etc/debian_version`
@@ -359,11 +368,11 @@ install_bin() {
       distro_id=debian
     elif test -f /etc/os-release; then
       # Suse, opensuse, amazon linux, centos (but not redhat)
-      distro_id=`sed -ne 's/^ID=//p' /etc/os-release | sed -e 's/^["'"'"']//' -e 's/["'"'"']$//' -e 's/\\\(.\)/\1/g'`
-      distro_version=`sed -ne 's/^VERSION_ID=//p' /etc/os-release | sed -e 's/^["'"'"']//' -e 's/["'"'"']$//' -e 's/\\\(.\)/\1/g'`
+      distro_id=$(sed -ne 's/^ID=//p' /etc/os-release | sed -e 's/^["'"'"']//' -e 's/["'"'"']$//' -e 's/\\\(.\)/\1/g')
+      distro_version=$(sed -ne 's/^VERSION_ID=//p' /etc/os-release | sed -e 's/^["'"'"']//' -e 's/["'"'"']$//' -e 's/\\\(.\)/\1/g')
     fi
   fi
-  
+
   distro_id=`echo "$distro_id" | tr '[:upper:]' '[:lower:]'`
   distro_version=`echo "$distro_version" | tr '[:upper:]' '[:lower:]'`
   case "$distro_id" in
@@ -372,7 +381,7 @@ install_bin() {
     centos) distro_id="rhel" ;;
     redhatenterpriseserver) distro_id="rhel" ;;
   esac
-  
+
   local distro="$distro_id-$distro_version"
 
   if test "$community" = 1; then
@@ -380,7 +389,7 @@ install_bin() {
   else
     amazon1="amzn64"
   fi
-  
+
   # Different versions of MongoDB have builds for different distributions.
   # As m allows installing old MongoDB versions, we can look for
   # binaries for distributions that the latest MongoDB release is not
@@ -396,27 +405,27 @@ install_bin() {
     debian-8*) distros="debian81 debian71" ;;
     debian-9*) distros="debian92 debian81 debian71" ;;
     debian-*)  distros="debian92 debian81 debian71" ;;
-    
+
     ubuntu-12*) distros="ubuntu1204 debian71" ;;
     ubuntu-14*) distros="ubuntu1404 ubuntu1204 debian71" ;;
     ubuntu-16*) distros="ubuntu1604 ubuntu1404 ubuntu1204 debian71" ;;
     ubuntu-18*) distros="ubuntu1804 ubuntu1604 ubuntu1404 ubuntu1204 debian71" ;;
     ubuntu-*)   distros="ubuntu1804 ubuntu1604 ubuntu1404 ubuntu1204" ;;
-    
+
     suse-10*) distros="" ;;
     suse-11*) distros="suse11" ;;
     suse-12*) distros="suse12 suse11" ;;
     suse-*)   distros="suse12 suse11" ;;
-    
+
     amzn-1) distros="$amazon1 rhel70 rhel62" ;;
     amzn-2) distros="amazon2 $amazon1 rhel70 rhel62" ;;
     amzn-*) distros="amazon2 $amazon1" ;;
-    
+
     rhel-5*) distros="rhel55 rhel57" ;;
     rhel-6*) distros="rhel62 rhel55 rhel57 $amazon1" ;;
     rhel-7*) distros="rhel70 rhel62 rhel55 rhel57 $amazon1" ;;
     rhel-*)  distros="rhel70 rhel62 rhel55 rhel57" ;;
-    
+
     *) distros="" ;;
   esac
 
@@ -945,6 +954,7 @@ list_posts() {
   fi
 }
 
+
 # Handle arguments
 
 if test $# -eq 0; then
@@ -957,6 +967,7 @@ else
       lls|installed) display_versions $2; exit ;;
       --latest) display_latest_version $2; exit ;;
       --stable) display_latest_stable_version $2; exit ;;
+      --legacy) install_legacy $@; exit ;;
       bin|which) display_bin_path_for_version $2; exit ;;
       as|use|mongod) shift; execute_with_version $@; exit ;;
       sd|shard|mongos) shift; execute_shard_with_version $@; exit ;;

--- a/bin/m
+++ b/bin/m
@@ -315,6 +315,44 @@ install_bin() {
     sslbuild=$os
   fi
 
+  local DISTRO="`lsb_release -si`-`lsb_release -sr`"
+  local distro=`echo $DISTRO | tr '[:upper:]' '[:lower:]'`
+  # Different versions of MongoDB have builds for different distributions.
+  # As m allows installing old MongoDB versions, we can look for
+  # binaries for distributions that the latest MongoDB release is not
+  # built for. Conversely, an old MongoDB version does not have to have
+  # builds available for distributions that the latest version supports.
+  #
+  # The logic generally is to start with the correct distribution, then try
+  # one version older and one version newer. This should handle most cases
+  # reasonably well.
+  case "$distro" in
+    debian-6.*)
+      distros="debian71 debian81" ;;
+    debian-7.*)
+      distros="debian71 debian81" ;;
+    debian-8.*)
+      distros="debian81 debian71 debian92" ;;
+    debian-9.*)
+      distros="debian92 debian81 debian71" ;;
+    debian-*)
+      distros="debian92 debian81 debian71" ;;
+    
+    ubuntu-12.*)
+      distros="ubuntu1204 ubuntu1404" ;;
+    ubuntu-14.*)
+      distros="ubuntu1404 ubuntu1204 ubuntu1604" ;;
+    ubuntu-16.*)
+      distros="ubuntu1604 ubuntu1404 ubuntu1204" ;;
+    ubuntu-18.*)
+      distros="ubuntu1604 ubuntu1404 ubuntu1204" ;;
+    ubuntu-*)
+      distros="ubuntu1604 ubuntu1404 ubuntu1204" ;;
+    
+    *)
+      distros="" ;;
+  esac
+
   # determine the download url
   if [[ "$community" == 1 ]]; then
     local tarball="mongodb-$sslbuild-$arch-$version.tgz"

--- a/bin/m
+++ b/bin/m
@@ -275,7 +275,6 @@ install_bin() {
   local config=$2
   local community=1
 
-
   # check if enterprise
   if [[ $version == *-ent ]]; then
     community=0
@@ -322,7 +321,29 @@ install_bin() {
     local url="http://fastdl.mongodb.org/$os/$tarball"
   else # enterprise version
     if [[ "$os" == linux ]]; then
-      local tarball="mongodb-$os-$arch-enterprise-rhel70-$version.tgz" # for linux fetch the rhel7 tarball
+      # for linux fetch the rhel7 tarball by default
+      local dist=rhel70
+      if test -e /etc/debian_version; then
+        local debian_version=`cat /etc/debian_version`
+        case "$debian_version" in
+          wheezy* )
+            debian_versions="71"
+            ;;
+          jessie* )
+            debian_versions="81 71"
+            ;;
+          * )
+            debian_versions="92 81 71"
+            ;;
+        esac
+        for debian_version in $debian_versions; do
+          if good "http://downloads.10gen.com/$os/mongodb-$os-$arch-enterprise-debian$debian_version-$version.tgz"; then
+            dist=debian$debian_version
+            break
+          fi
+        done
+      fi
+      local tarball="mongodb-$os-$arch-enterprise-$dist-$version.tgz"
     else
       local tarball="mongodb-$os-$arch-enterprise-$version.tgz"
     fi

--- a/bin/m
+++ b/bin/m
@@ -52,10 +52,10 @@ fi
 GET=
 
 # wget support (Added --no-check-certificate for Github downloads)
-which wget 2>&1 > /dev/null && GET="wget -q -O-"
+which wget >/dev/null 2>&1 && GET="wget -q -O-"
 
 # curl support
-which curl 2>&1 > /dev/null && GET="curl -# -L"
+which curl >/dev/null 2>&1 && GET="curl -# -L"
 
 # Ensure we have curl or wget
 
@@ -197,6 +197,10 @@ display_versions() {
 #
 
 install_mongo() {
+  if [ "$1" = "--legacy" ]; then
+    _legacy_only=y
+    shift
+  fi
   local version=$1; shift
   local config=$@
   check_current_version
@@ -236,17 +240,6 @@ install_mongo() {
     prompt_install "MongoDB version $version is not installed."
     install_bin $version $config
   fi
-}
-
-#
-# Install legacy version (Linux generic version)
-#
-
-install_legacy() {
-  echo "LEGACY"
-  _legacy_only=y
-  shift
-  install_mongo $@
 }
 
 #
@@ -954,7 +947,6 @@ list_posts() {
   fi
 }
 
-
 # Handle arguments
 
 if test $# -eq 0; then
@@ -967,7 +959,6 @@ else
       lls|installed) display_versions $2; exit ;;
       --latest) display_latest_version $2; exit ;;
       --stable) display_latest_stable_version $2; exit ;;
-      --legacy) install_legacy $@; exit ;;
       bin|which) display_bin_path_for_version $2; exit ;;
       as|use|mongod) shift; execute_with_version $@; exit ;;
       sd|shard|mongos) shift; execute_shard_with_version $@; exit ;;

--- a/bin/m
+++ b/bin/m
@@ -195,6 +195,10 @@ display_versions() {
 #
 
 install_mongo() {
+  if [ "$1" -eq "--legacy" ]; then
+    _legacy_only=y
+    shift
+  fi
   local version=$1; shift
   local config=$@
   check_current_version
@@ -435,6 +439,10 @@ install_bin() {
     *)
       distros="" ;;
   esac
+
+  if [ "$_legacy_only" = y ]; then
+    distros=""
+  fi
 
   # determine the download url
   if [[ "$community" == 1 ]]; then

--- a/bin/m
+++ b/bin/m
@@ -317,7 +317,7 @@ install_bin() {
 
   local distro_id= distro_version=
   if lsb_release >/dev/null 2>&1; then
-    # Debian/Ubuntu
+    # Debian/Ubuntu, also RHEL proper but not centos
     distro_id=`lsb_release -si`
     distro_version=`lsb_release -sr`
     if test "$distro_version" = testing; then
@@ -433,26 +433,13 @@ install_bin() {
     if [[ "$os" == linux ]]; then
       # for linux fetch the rhel7 tarball by default
       local dist=rhel70
-      if test -e /etc/debian_version; then
-        local debian_version=`cat /etc/debian_version`
-        case "$debian_version" in
-          wheezy* )
-            debian_versions="71"
-            ;;
-          jessie* )
-            debian_versions="81 71"
-            ;;
-          * )
-            debian_versions="92 81 71"
-            ;;
-        esac
-        for debian_version in $debian_versions; do
-          if good "http://downloads.10gen.com/$os/mongodb-$os-$arch-enterprise-debian$debian_version-$version.tgz"; then
-            dist=debian$debian_version
-            break
-          fi
-        done
-      fi
+      # shadowing earlier $distro
+      for distro in $distros; do
+        if good "http://downloads.10gen.com/$os/mongodb-$os-$arch-enterprise-$distro-$version.tgz"; then
+          dist=$distro
+          break
+        fi
+      done
       local tarball="mongodb-$os-$arch-enterprise-$dist-$version.tgz"
     else
       local tarball="mongodb-$os-$arch-enterprise-$version.tgz"

--- a/bin/m
+++ b/bin/m
@@ -378,24 +378,24 @@ install_bin() {
   # one version older and one version newer. This should handle most cases
   # reasonably well.
   case "$distro" in
-    debian-6.*)
+    debian-6*)
       distros="debian71 debian81" ;;
-    debian-7.*)
+    debian-7*)
       distros="debian71 debian81" ;;
-    debian-8.*)
+    debian-8*)
       distros="debian81 debian71 debian92" ;;
-    debian-9.*)
+    debian-9*)
       distros="debian92 debian81 debian71" ;;
     debian-*)
       distros="debian92 debian81 debian71" ;;
     
-    ubuntu-12.*)
+    ubuntu-12*)
       distros="ubuntu1204 ubuntu1404" ;;
-    ubuntu-14.*)
+    ubuntu-14*)
       distros="ubuntu1404 ubuntu1204 ubuntu1604" ;;
-    ubuntu-16.*)
+    ubuntu-16*)
       distros="ubuntu1604 ubuntu1404 ubuntu1204" ;;
-    ubuntu-18.*)
+    ubuntu-18*)
       distros="ubuntu1604 ubuntu1404 ubuntu1204" ;;
     ubuntu-*)
       distros="ubuntu1604 ubuntu1404 ubuntu1204" ;;

--- a/bin/m
+++ b/bin/m
@@ -410,7 +410,12 @@ install_bin() {
       distros="suse12 suse11 suse10" ;;
     
     amzn-*)
-      distros="amzn64" ;;
+      if test "$community" = 1; then
+        distros=amazon
+      else
+        distros="amzn64"
+      fi
+      ;;
     
     rhel-5*)
       distros="rhel57" ;;

--- a/bin/m
+++ b/bin/m
@@ -428,6 +428,13 @@ install_bin() {
   # determine the download url
   if [[ "$community" == 1 ]]; then
     local tarball="mongodb-$sslbuild-$arch-$version.tgz"
+    # shadowing earlier $distro
+    for distro in $distros; do
+      if good "http://fastdl.mongodb.org/$os/mongodb-$sslbuild-$arch-$distro-$version.tgz"; then
+        tarball="mongodb-$sslbuild-$arch-$distro-$version.tgz"
+        break
+      fi
+    done
     local url="http://fastdl.mongodb.org/$os/$tarball"
   else # enterprise version
     if [[ "$os" == linux ]]; then

--- a/bin/m
+++ b/bin/m
@@ -315,8 +315,59 @@ install_bin() {
     sslbuild=$os
   fi
 
-  local DISTRO="`lsb_release -si`-`lsb_release -sr`"
-  local distro=`echo $DISTRO | tr '[:upper:]' '[:lower:]'`
+  local distro_id= distro_version=
+  if lsb_release >/dev/null 2>&1; then
+    # Debian/Ubuntu
+    distro_id=`lsb_release -si`
+    distro_version=`lsb_release -sr`
+    if test "$distro_version" = testing; then
+      distro_version=
+    fi
+  fi
+  if test -z "$distro_version" && test -f /etc/debian_version; then
+    # Debian without lsb_release installed, or Debian testing or sid.
+    # (We don't handle sid.)
+    # This will also catch ubuntus that don't have lsb_release installed,
+    # which is not good
+    distro_version=`cat /etc/debian_version`
+    case "$distro_version" in
+      etch*)
+        distro_version=4 ;;
+      lenny*)
+        distro_version=5 ;;
+      squeeze*)
+        distro_version=6 ;;
+      wheezy*)
+        distro_version=7 ;;
+      jessie*)
+        distro_version=8 ;;
+      stretch*)
+        distro_version=9 ;;
+      buster*)
+        distro_version=10 ;;
+      bullseye*)
+        distro_version=11 ;;
+      bookworm*)
+        distro_version=12 ;;
+    esac
+    distro_id=debian
+  elif test -f /etc/os-release; then
+    # Suse, opensuse, amazon linux, centos (but not redhat)
+    distro_id=`(. /etc/os-release && echo $ID) | tr '[:upper:]' '[:lower:]'`
+    distro_version=`(. /etc/os-release && echo $VERSION_ID)`
+  fi
+  
+  distro_id=`echo "$distro_id" | tr '[:upper:]' '[:lower:]'`
+  distro_version=`echo "$distro_version" | tr '[:upper:]' '[:lower:]'`
+  if test "$distro_id" = sles || test "$distro_id" = opensuse; then
+    distro_id=suse
+  fi
+  if test "$distro_id" = centos || test "$distro_id" = redhatenterpriseserver; then
+    distro_id=rhel
+  fi
+  
+  local distro=$distro_id:$distro_version
+  
   # Different versions of MongoDB have builds for different distributions.
   # As m allows installing old MongoDB versions, we can look for
   # binaries for distributions that the latest MongoDB release is not
@@ -348,6 +399,27 @@ install_bin() {
       distros="ubuntu1604 ubuntu1404 ubuntu1204" ;;
     ubuntu-*)
       distros="ubuntu1604 ubuntu1404 ubuntu1204" ;;
+    
+    suse-10*)
+      distros="suse10" ;;
+    suse-11*)
+      distros="suse11 suse10" ;;
+    suse-12*)
+      distros="suse12 suse11 suse10" ;;
+    suse-*)
+      distros="suse12 suse11 suse10" ;;
+    
+    amzn-*)
+      distros="amzn64" ;;
+    
+    rhel-5*)
+      distros="rhel57" ;;
+    rhel-6*)
+      distros="rhel62 rhel57" ;;
+    rhel-7*)
+      distros="rhel72 rhel71 rhel70 rhel62 rhel57" ;;
+    rhel-*)
+      distros="rhel72 rhel71 rhel70 rhel62 rhel57" ;;
     
     *)
       distros="" ;;

--- a/bin/m
+++ b/bin/m
@@ -366,7 +366,7 @@ install_bin() {
     distro_id=rhel
   fi
   
-  local distro=$distro_id:$distro_version
+  local distro=$distro_id-$distro_version
   
   # Different versions of MongoDB have builds for different distributions.
   # As m allows installing old MongoDB versions, we can look for

--- a/bin/m
+++ b/bin/m
@@ -377,6 +377,12 @@ install_bin() {
   esac
   
   local distro="$distro_id-$distro_version"
+
+  if test "$community" = 1; then
+    amazon1="amazon"
+  else
+    amazon1="amzn64"
+  fi
   
   # Different versions of MongoDB have builds for different distributions.
   # As m allows installing old MongoDB versions, we can look for
@@ -389,52 +395,51 @@ install_bin() {
   # reasonably well.
   case "$distro" in
     debian-6*)
-      distros="debian71 debian81" ;;
+      distros="" ;;
     debian-7*)
-      distros="debian71 debian81" ;;
+      distros="debian71" ;;
     debian-8*)
-      distros="debian81 debian71 debian92" ;;
+      distros="debian81 debian71" ;;
     debian-9*)
       distros="debian92 debian81 debian71" ;;
     debian-*)
       distros="debian92 debian81 debian71" ;;
     
     ubuntu-12*)
-      distros="ubuntu1204 ubuntu1404" ;;
+      distros="ubuntu1204 debian71" ;;
     ubuntu-14*)
-      distros="ubuntu1404 ubuntu1204 ubuntu1604" ;;
+      distros="ubuntu1404 ubuntu1204 debian71" ;;
     ubuntu-16*)
-      distros="ubuntu1604 ubuntu1404 ubuntu1204" ;;
+      distros="ubuntu1604 ubuntu1404 ubuntu1204 debian71" ;;
     ubuntu-18*)
-      distros="ubuntu1804 ubuntu1604 ubuntu1404 ubuntu1204" ;;
+      distros="ubuntu1804 ubuntu1604 ubuntu1404 ubuntu1204 debian71" ;;
     ubuntu-*)
       distros="ubuntu1804 ubuntu1604 ubuntu1404 ubuntu1204" ;;
     
     suse-10*)
-      distros="suse10" ;;
+      distros="" ;;
     suse-11*)
-      distros="suse11 suse10" ;;
+      distros="suse11" ;;
     suse-12*)
-      distros="suse12 suse11 suse10" ;;
+      distros="suse12 suse11" ;;
     suse-*)
-      distros="suse12 suse11 suse10" ;;
+      distros="suse12 suse11" ;;
     
+    amzn-1)
+      distros="$amazon1 rhel70 rhel62" ;;
+    amzn-2)
+      distros="amazon2 $amazon1 rhel70 rhel62" ;;
     amzn-*)
-      if test "$community" = 1; then
-        distros="amazon"
-      else
-        distros="amzn64"
-      fi
-      ;;
+      distros="amazon2 $amazon1" ;;
     
     rhel-5*)
-      distros="rhel57" ;;
+      distros="rhel55 rhel57" ;;
     rhel-6*)
-      distros="rhel62 rhel57" ;;
+      distros="rhel62 rhel55 rhel57 $amazon1" ;;
     rhel-7*)
-      distros="rhel72 rhel71 rhel70 rhel62 rhel57" ;;
+      distros="rhel70 rhel62 rhel55 rhel57 $amazon1" ;;
     rhel-*)
-      distros="rhel72 rhel71 rhel70 rhel62 rhel57" ;;
+      distros="rhel70 rhel62 rhel55 rhel57" ;;
     
     *)
       distros="" ;;

--- a/bin/m
+++ b/bin/m
@@ -394,55 +394,33 @@ install_bin() {
   # one version older and one version newer. This should handle most cases
   # reasonably well.
   case "$distro" in
-    debian-6*)
-      distros="" ;;
-    debian-7*)
-      distros="debian71" ;;
-    debian-8*)
-      distros="debian81 debian71" ;;
-    debian-9*)
-      distros="debian92 debian81 debian71" ;;
-    debian-*)
-      distros="debian92 debian81 debian71" ;;
+    debian-6*) distros="" ;;
+    debian-7*) distros="debian71" ;;
+    debian-8*) distros="debian81 debian71" ;;
+    debian-9*) distros="debian92 debian81 debian71" ;;
+    debian-*)  distros="debian92 debian81 debian71" ;;
     
-    ubuntu-12*)
-      distros="ubuntu1204 debian71" ;;
-    ubuntu-14*)
-      distros="ubuntu1404 ubuntu1204 debian71" ;;
-    ubuntu-16*)
-      distros="ubuntu1604 ubuntu1404 ubuntu1204 debian71" ;;
-    ubuntu-18*)
-      distros="ubuntu1804 ubuntu1604 ubuntu1404 ubuntu1204 debian71" ;;
-    ubuntu-*)
-      distros="ubuntu1804 ubuntu1604 ubuntu1404 ubuntu1204" ;;
+    ubuntu-12*) distros="ubuntu1204 debian71" ;;
+    ubuntu-14*) distros="ubuntu1404 ubuntu1204 debian71" ;;
+    ubuntu-16*) distros="ubuntu1604 ubuntu1404 ubuntu1204 debian71" ;;
+    ubuntu-18*) distros="ubuntu1804 ubuntu1604 ubuntu1404 ubuntu1204 debian71" ;;
+    ubuntu-*)   distros="ubuntu1804 ubuntu1604 ubuntu1404 ubuntu1204" ;;
     
-    suse-10*)
-      distros="" ;;
-    suse-11*)
-      distros="suse11" ;;
-    suse-12*)
-      distros="suse12 suse11" ;;
-    suse-*)
-      distros="suse12 suse11" ;;
+    suse-10*) distros="" ;;
+    suse-11*) distros="suse11" ;;
+    suse-12*) distros="suse12 suse11" ;;
+    suse-*)   distros="suse12 suse11" ;;
     
-    amzn-1)
-      distros="$amazon1 rhel70 rhel62" ;;
-    amzn-2)
-      distros="amazon2 $amazon1 rhel70 rhel62" ;;
-    amzn-*)
-      distros="amazon2 $amazon1" ;;
+    amzn-1) distros="$amazon1 rhel70 rhel62" ;;
+    amzn-2) distros="amazon2 $amazon1 rhel70 rhel62" ;;
+    amzn-*) distros="amazon2 $amazon1" ;;
     
-    rhel-5*)
-      distros="rhel55 rhel57" ;;
-    rhel-6*)
-      distros="rhel62 rhel55 rhel57 $amazon1" ;;
-    rhel-7*)
-      distros="rhel70 rhel62 rhel55 rhel57 $amazon1" ;;
-    rhel-*)
-      distros="rhel70 rhel62 rhel55 rhel57" ;;
+    rhel-5*) distros="rhel55 rhel57" ;;
+    rhel-6*) distros="rhel62 rhel55 rhel57 $amazon1" ;;
+    rhel-7*) distros="rhel70 rhel62 rhel55 rhel57 $amazon1" ;;
+    rhel-*)  distros="rhel70 rhel62 rhel55 rhel57" ;;
     
-    *)
-      distros="" ;;
+    *) distros="" ;;
   esac
 
   if [ "$_legacy_only" = y ]; then

--- a/bin/m
+++ b/bin/m
@@ -321,7 +321,7 @@ install_bin() {
 
   local distro_id= distro_version=
   if lsb_release >/dev/null 2>&1; then
-    # Debian/Ubuntu, also RHEL proper but not centos
+    # If the lsb_release(1) tool is installed, use it.
     distro_id=`lsb_release -si`
     distro_version=`lsb_release -sr`
     if test "$distro_version" = testing; then
@@ -334,10 +334,7 @@ install_bin() {
       distro_id=`sed -ne 's/^DISTRIB_ID=//p' /etc/os-release | sed -e 's/^["'"'"']//' -e 's/["'"'"']$//' -e 's/\\\(.\)/\1/g'`
       distro_version=`sed -ne 's/^DISTRIB_RELEASE=//p' /etc/os-release | sed -e 's/^["'"'"']//' -e 's/["'"'"']$//' -e 's/\\\(.\)/\1/g'`
     elif test -f /etc/debian_version; then
-      # Debian without lsb_release installed, or Debian testing or sid.
-      # (We don't handle sid.)
-      # This will also catch ubuntus that don't have lsb_release installed,
-      # which is not good
+      # Debian generally doesn't install lsb_release(1) or a /etc/lsb-release file, so we figure it out manually.
       distro_version=`cat /etc/debian_version`
       case "$distro_version" in
         etch|etch/*)


### PR DESCRIPTION
This PR encapsulates the changes in #40 and https://github.com/devkev/m/tree/distros.

Although the utmost care was taken to ensure that it doesn't break things, this is a major change to `m` that will probably behave unexpectedly to people familiar with `m` over the years.

Short description of changes: This release will try to recognize the underlying Linux distro, and install distro-specific `mongod` version. This is done to enable SSL support, which was previously not available to `m`-installed `mongod` in Linux.

The supported distro list tracks pretty closely the [supported platforms in the production notes](https://docs.mongodb.com/manual/administration/production-notes/#supported-platforms):
- Amazon Linux 1 & 2
- Debian 7, 8, 9
- SUSE Linux
- Ubuntu 12.04, 14.04, 16.04, 18.04

For example, some versions e.g. Ubuntu 18.04 only supports MongoDB 4.0.0 and not older versions.