### PR TITLE
Added Support to Download Enterprise Build (Binary Version) for Linux Distributions

### DIFF
--- a/bin/m
+++ b/bin/m
@@ -32,7 +32,7 @@ CACHE_SRC=${M_CACHE_SRC:-$M_DIR/cache-src.txt}
 CACHE_EXPIRY=${M_CACHE_EXPIRY:-3600}
 
 # m version
-VERSION="1.5.6"
+VERSION="1.5.7"
 
 #
 # Log the given <msg ...>
@@ -497,7 +497,7 @@ install_bin() {
   fi
 
   distro_id=`echo "$distro_id" | tr '[:upper:]' '[:lower:]'`
-  distro_version=`echo "$distro_version" | tr '[:upper:]' '[:lower:]'`
+  distro_version=`echo "$distro_version" | tr '[:upper:]' '[:lower:]' | sed -e 's/\.//'`
   case "$distro_id" in
     sles) distro_id="suse" ;;
     opensuse) distro_id="suse" ;;
@@ -506,7 +506,7 @@ install_bin() {
     redhatenterpriseserver) distro_id="rhel" ;;
   esac
 
-  local distro="$distro_id-$distro_version"
+  local distro="$distro_id$distro_version"
 
   if test "$community" = 1; then
     amazon1="amazon"
@@ -578,15 +578,7 @@ install_bin() {
   else # enterprise version
     case $os in
       linux* )
-        # for linux fetch the rhel7 tarball by default
-        local dist=rhel70
-        # shadowing earlier $distro
-        for distro in $distros; do
-          if good "http://downloads.10gen.com/$os/mongodb-$os-$arch-enterprise-$distro-$version.tgz"; then
-            dist=$distro
-            break
-          fi
-        done
+	local tarball="mongodb-$os-$arch-enterprise-$distro-$version.tgz"
         ;;
       osx* )
         local tarball="mongodb-$sslbuild-$arch-enterprise-$version.tgz"


### PR DESCRIPTION
Added support to download enterprise builds for Linux distros (binary version), tarball in download URL was malformed. Made the following changes:
- The new one is: mongodb-$os-$arch-enterprise-$distro-$version.tgz
- The distro variable is now "$distro_id$distro_version" (removed "-")
- The distro_version variable has the "." removed
- Advanced version number to 1.5.7

Should work for all Linux distros but have only tested for Ubuntu.