### PR TITLE
Add Debian 10 support, unbreak enterprise installation

### DIFF
--- a/bin/m
+++ b/bin/m
@@ -530,7 +530,8 @@ install_bin() {
     debian-7*) distros="debian71" ;;
     debian-8*) distros="debian81 debian71" ;;
     debian-9*) distros="debian92 debian81 debian71" ;;
-    debian-*)  distros="debian92 debian81 debian71" ;;
+    debian-10*) distros="debian10 debian92 debian81 debian71" ;;
+    debian-*)  distros="debian10 debian92 debian81 debian71" ;;
 
     ubuntu-12*) distros="ubuntu1204 debian71" ;;
     ubuntu-14*) distros="ubuntu1404 ubuntu1204 debian71" ;;

--- a/bin/m
+++ b/bin/m
@@ -583,7 +583,7 @@ install_bin() {
         local dist=rhel70
         # shadowing earlier $distro
         for distro in $distros; do
-          if good "http://downloads.10gen.com/$os/mongodb-$os-$arch-enterprise-$distro-$version.tgz"; then
+          if good "https://downloads.mongodb.com/$os/mongodb-$os-$arch-enterprise-$distro-$version.tgz"; then
             dist=$distro
             break
           fi
@@ -596,7 +596,7 @@ install_bin() {
         local tarball="mongodb-$os-$arch-enterprise-$version.tgz" ;;
     esac
     version="$version-ent"
-    local url="http://downloads.10gen.com/$os/$tarball"
+    local url="https://downloads.mongodb.com/$os/$tarball"
   fi
 
   debug "Default: $url"

--- a/bin/m
+++ b/bin/m
@@ -585,6 +585,7 @@ install_bin() {
         for distro in $distros; do
           if good "https://downloads.mongodb.com/$os/mongodb-$os-$arch-enterprise-$distro-$version.tgz"; then
             dist=$distro
+            tarball="mongodb-$os-$arch-enterprise-$distro-$version.tgz"
             break
           fi
         done


### PR DESCRIPTION
The enterprise installation appears to be broken on master because `tarball` is never assigned. This PR fixes that and also adds `debian10` as a known distro for 4.4 server. Lastly it changes the download host from downloads.10gen.com to downloads.mongodb.com which is what the download center currently references.

Tested with 4.3.4 and 4.3.4-ent on Debian 10 and Ubuntu 18.04.