### PR TITLE
Fix detection of enterprise versions in 4.4+

### DIFF
--- a/bin/m
+++ b/bin/m
@@ -223,7 +223,7 @@ check_current_version() {
   which mongo &> /dev/null
   if test $? -eq 0; then
     active=`mongod --version | grep "version\s*v[0-9]" | egrep -o '[0-9]+\.[0-9]+\.[0-9]+([-_\.][a-zA-Z0-9]+)?' | head -1`
-    ent=`mongod --version | egrep "modules:\s*enterprise" | wc -l`
+    ent=`mongod --version | egrep "(modules:\s*)|\"enterprise\"?" | wc -l`
     if [[ $ent == *1 ]]; then
       active="$active-ent"
     fi


### PR DESCRIPTION
MongoDB 4.4 changes the output of `mongod --version`, which breaks active version detection when an enterprise version is active:
```
$ m
  ο 4.2.12-ent 
    4.4.3-ent 
$ mongod --version
db version v4.2.12
git version: 5593fd8e33b60c75802edab304e23998fa0ce8a5
allocator: system
modules: enterprise 
build environment:
    distarch: x86_64
    target_arch: x86_64

$ m 4.4.3-ent
Activating 4.4.3-ent

$ mongod --version
db version v4.4.3
Build Info: {
    "version": "4.4.3",
    "gitVersion": "913d6b62acfbb344dde1b116f4161360acd8fd13",
    "modules": [
        "enterprise"
    ],
    "allocator": "system",
    "environment": {
        "distarch": "x86_64",
        "target_arch": "x86_64"
    }
}

$ m
    4.2.12-ent 
    4.4.3-ent 
```

I'm not sure the solution suggested here is free of unwanted side effects, but it's the best I could come up with. `egrep` works line by line, so we can't match on the JSON output directly. The updated regular expression matches on both 4.2 and 4.4:
```
$ /usr/local/m/versions/4.2.12-ent/bin/mongod --version | egrep "(modules:\s*)|\"enterprise\"?"
modules: enterprise 

$ /usr/local/m/versions/4.4.3-ent/bin/mongod --version | egrep "(modules:\s*)|\"enterprise\"?"
        "enterprise"
```