### PR TITLE
Use -(min|max)depth in find instead of -depth

### DIFF
--- a/bin/m
+++ b/bin/m
@@ -1117,7 +1117,7 @@ get_latest_installed_version() {
     local series="${BASH_REMATCH[1]}"
     local ent="${BASH_REMATCH[2]}"
 
-    version=`find ${VERSIONS_DIR} -type d -depth 1 \
+    version=`find ${VERSIONS_DIR} -mindepth 1 -maxdepth 1 -type d \
       | egrep -o "$series\.[0-9]+([-_\.]rc[0-9]+)?" \
       | sort -u -k 1,1n -k 2,2n -k 3,3n -t . \
       | tail -n1`


### PR DESCRIPTION
-depth N is only supported in BSD, -min/maxdepth seems to be supported everywhere. Placing them before other options also removes a warning:

```
$ find /home/ubuntu/.local/m/versions -type d -depth
find: warning: you have specified the -depth option after a non-option argument -type, but options are not positional (-depth affects tests specified before it as well as those specified after it).  Please specify options before other arguments.

find: paths must precede expression: `1'
$ find /home/ubuntu/.local/m/versions -maxdepth 1 -mindepth 1 -type d
/home/ubuntu/.local/m/versions/5.0.5
/home/ubuntu/.local/m/versions/5.2.0-rc2
/home/ubuntu/.local/m/versions/5.1.1
```