### PR TITLE
report failure of tools installation

### DIFF
--- a/bin/m
+++ b/bin/m
@@ -390,6 +390,13 @@ install_tools_bin() {
   printf "Downloading from https://fastdl.mongodb.org/tools/db/mongodb-database-tools-$dist-$arch-$version.$ext"
 
   $GET https://fastdl.mongodb.org/tools/db/mongodb-database-tools-$dist-$arch-$version.$ext -o $M_DIR/tools-$version.$ext
+  if test $? -gt 0; then
+    printf "Error: tools installation failed\n"
+    printf "  Tarball fetch for MongoDB tools version $version failed.\n"
+    printf "  Try a different version or view $logpath to view\n"
+    printf "  error details.\n"
+    exit 1
+  fi
   mkdir -p $TOOLS_DIR/$version
   if [[ $ext = "zip" ]]; then
     unzip -q $M_DIR/tools-$version.zip -d $TOOLS_DIR/$version


### PR DESCRIPTION
Today I had a fluke DNS failure on the tools installation step and `m` reported a success status code. I was using it to gain access to the tools in a container build, so the whole container build kept on trucking. I realize this is mostly a tool for dev environments, but I thought I'd contribute a check so that the script fails properly in this situation.

Thanks for creating and maintaining `m`! It is greatly appreciated.