### PR TITLE
fix error message when using GNU egrep

### DIFF
--- a/bin/m
+++ b/bin/m
@@ -223,8 +223,8 @@ get_all_versions() {
 check_current_version() {
   which mongo &> /dev/null
   if test $? -eq 0; then
-    active=`mongod --version | grep "version\s*v[0-9]" | egrep -o '[0-9]+\.[0-9]+\.[0-9]+([-_\.][a-zA-Z0-9]+)?' | head -1`
-    ent=`mongod --version | egrep "(modules:\s*)|\"enterprise\"?" | wc -l`
+    active=`mongod --version | grep "version\s*v[0-9]" | grep -E -o '[0-9]+\.[0-9]+\.[0-9]+([-_\.][a-zA-Z0-9]+)?' | head -1`
+    ent=`mongod --version | grep -E "(modules:\s*)|\"enterprise\"?" | wc -l`
     if [[ $ent == *1 ]]; then
       active="$active-ent"
     fi
@@ -444,7 +444,7 @@ get_all_tools_versions() {
   get_all_versions
 
   server_versions=`echo $all_versions \
-    | egrep -o "$tools_regex$rc_regex" \
+    | grep -E -o "$tools_regex$rc_regex" \
     | sort -u \
     | sort -s -k 2.3n -t - \
     | sort -s -k 1,1n -k 2,2n -k 3,3n -t . \
@@ -605,18 +605,18 @@ install_mongo() {
     printf ">> Checking for $flavour release of MongoDB $version\n"
 
     if test "$flavour" = "latest"; then
-      debug "egrep -o \"$series\.[0-9]+$rc\""
+      debug "grep -E -o \"$series\.[0-9]+$rc\""
       version=`echo $all_versions \
         | grep '"version\":' \
-        | egrep -o "$series\.[0-9]+$rc" \
+        | grep -E -o "$series\.[0-9]+$rc" \
         | sort -u -k 1,1n -k 2,2n -k 3,3n -t . \
         | tail -n1`
     else
-      debug "egrep -v \"[-]rc\" | egrep -o \"$series\.[0-9]+\" "
+      debug "grep -E -v \"[-]rc\" | grep -E -o \"$series\.[0-9]+\" "
 
       version=`echo $all_versions \
         | grep '"version\":' \
-        | egrep -o "$series\.[0-9]+\.zip" \
+        | grep -E -o "$series\.[0-9]+\.zip" \
         | sed s/.zip$// \
         | sort -u -k 1,1n -k 2,2n -k 3,3n -t . \
         | tail -n1`
@@ -1143,7 +1143,7 @@ get_latest_installed_version() {
     local series="${BASH_REMATCH[1]}\.${BASH_REMATCH[2]}"
     local ent="${BASH_REMATCH[3]}"
     version=`find ${VERSIONS_DIR} -mindepth 1 -maxdepth 1 -type d \
-      | egrep -o "$series\.[0-9]+([-_\.]rc[0-9]+)?" \
+      | grep -E -o "$series\.[0-9]+([-_\.]rc[0-9]+)?" \
       | sort -u -k 1,1n -k 2,2n -k 3,3n -t . \
       | tail -n1`
     if [[ -z "$version" ]]; then
@@ -1228,8 +1228,8 @@ display_latest_version() {
 
   if [[ $version =~ ^[0-9]\.[0-9]+$ ]]; then
     echo $all_versions \
-      | egrep -o "$version\.[0-9]+([-_\.]rc[0-9]+)?" \
-      | egrep -v "\d-\d" \
+      | grep -E -o "$version\.[0-9]+([-_\.]rc[0-9]+)?" \
+      | grep -E -v "\d-\d" \
       | uniq \
       | sort -u -k 1,1n -k 2,2n -k 3,3n -t . \
       | tail -n1
@@ -1238,8 +1238,8 @@ display_latest_version() {
       abort "Version [$version] does not match the MongoDB release series format (X.Y)"
     else
       echo $all_versions \
-        | egrep -o '[0-9]\.[0-9]+\.[0-9]+([-_\.]rc[0-9]+)?' \
-        | egrep -v "\d-\d" \
+        | grep -E -o '[0-9]\.[0-9]+\.[0-9]+([-_\.]rc[0-9]+)?' \
+        | grep -E -v "\d-\d" \
         | uniq \
         | sort -u -k 1,1n -k 2,2n -k 3,3n -t . \
         | tail -n1
@@ -1260,16 +1260,16 @@ display_latest_stable_version() {
   if [[ $version =~ ^[0-4]\.[0246]+$ ]]; then
     debug "Stable version < 5.0 ($version) is X.Y (Y is even)"
     echo $all_versions \
-      | egrep -o "$version\.[0-9]+" \
-      | egrep -v "\d-\d" \
+      | grep -E -o "$version\.[0-9]+" \
+      | grep -E -v "\d-\d" \
       | uniq \
       | sort -u -k 1,1n -k 2,2n -k 3,3n -t . \
       | tail -n1
   elif [[ $version =~ ^[5-9]\.0$ ]]; then
     debug "Stable version >= 5.0 ($version) is X.0"
     echo $all_versions \
-      | egrep -o "$version\.[0-9]+" \
-      | egrep -v "\d-\d" \
+      | grep -E -o "$version\.[0-9]+" \
+      | grep -E -v "\d-\d" \
       | uniq \
       | sort -u -k 1,1n -k 2,2n -k 3,3n -t . \
       | tail -n1
@@ -1278,8 +1278,8 @@ display_latest_stable_version() {
       abort "Version [$version] does not match a stable MongoDB release series (X.Y)"
     else
       echo $all_versions \
-        | egrep -o '[5-9]+\.0+\.[0-9]+\.zip' \
-        | egrep -v "\d-\d" \
+        | grep -E -o '[5-9]+\.0+\.[0-9]+\.zip' \
+        | grep -E -v "\d-\d" \
         | uniq \
         | sed s/.zip$// \
         | sort -u -k 1,1n -k 2,2n -k 3,3n -t . \
@@ -1317,7 +1317,7 @@ list_versions() {
   get_all_versions
 
   versions=`echo $all_versions \
-    | egrep -o "$series\.[0-9]+$rc" \
+    | grep -E -o "$series\.[0-9]+$rc" \
     | sort -u \
     | sort -s -k 2.3n -t - \
     | sort -s -k 1,1n -k 2,2n -k 3,3n -t . \


### PR DESCRIPTION
Since GNU grep release 3.8 the egrep command prints a warning to STDERR that 'egrep is obsolescent', which is annoying. This commit change m to use `grep -E` instead, which is supported by both BSD and GNU grep.

Announcement of change to GNU egrep:
https://git.savannah.gnu.org/cgit/grep.git/tree/NEWS#n75

The GNU egrep warning can be found here:
https://git.savannah.gnu.org/cgit/grep.git/tree/src/egrep.sh#n3