### PR TITLE
Update for 1.8.5 release

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,8 @@
+1.8.5 / 2023-09-13
+==================
+ * Fix error message when using GNU egrep (@charlievieth)
+ * Docs: git:// should be replaced with https:// (@michaelstruening)
+
 1.8.4 / 2022-11-04
 ==================
  * Update detection for supported Linux distros as at MongoDB 6.0

--- a/bin/m
+++ b/bin/m
@@ -39,7 +39,7 @@ CACHE_SRC=${M_CACHE_SRC:-$M_DIR/cache-src.json}
 CACHE_EXPIRY=${M_CACHE_EXPIRY:-3600}
 
 # m version
-VERSION="1.8.4"
+VERSION="1.8.5"
 
 #
 # Log the given <msg ...>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "m",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "description": "mongodb version management",
   "homepage": "https://github.com/aheckmann/m",
   "bugs": "https://github.com/aheckmann/m/issues",


### PR DESCRIPTION
1.8.5 / 2023-09-13
==================
 * Fix error message when using GNU egrep (@charlievieth)
 * Docs: git:// should be replaced with https:// (@michaelstruening)
