### PR TITLE
Use "curl -s" (silent) instead of "curl -#"

### DIFF
--- a/bin/m
+++ b/bin/m
@@ -107,7 +107,7 @@ GET=
 which wget >/dev/null 2>&1 && GET="wget -q -O-"
 
 # curl support
-which curl >/dev/null 2>&1 && GET="curl -# -L"
+which curl >/dev/null 2>&1 && GET="curl -s -L"
 
 # Ensure we have curl or wget
 


### PR DESCRIPTION
When `wget` is selected as the binary for `GET`, it uses the `-q` ("quiet") option which suppresses output. However, when `curl` is used, it uses the `-#` option which prints a progress bar during download. 

This change replaces the `-#` option to `curl` with `-s` ("silent") instead. This makes the behavior consistent with what happens when `wget` is used; in many cases (such as using `m` to download a specific version of mongo for running tests in CI) the progress bar can generate a lot of spammy log output, so it's better off without it IMO.