### PR TITLE
Add support for Pop_OS! linux distribution

### DIFF
--- a/bin/m
+++ b/bin/m
@@ -929,6 +929,7 @@ get_distro_and_arch() {
     redhatenterpriseserver) distro_id="rhel" ;;
     rocky) distro_id="rhel" ;;
     neon) distro_id="ubuntu" ;;
+    pop) distro_id="ubuntu" ;;
   esac
 
   distro="$distro_id-$distro_version"


### PR DESCRIPTION
Pop_OS! is among the top 10 Linux distribution [according to Distrowatch](https://distrowatch.com/index.php?dataspan=52) and is based on Ubuntu