### PR TITLE
Add support for Amazon Linux 2023

### DIFF
--- a/bin/m
+++ b/bin/m
@@ -983,6 +983,7 @@ get_distro_and_arch() {
     amzn-1) distros="$amazon1 rhel70 rhel62" ;;
     amzn-2018.03) distros="$amazon1 rhel70 rhel62" ;;
     amzn-2) distros="amazon2 $amazon1 rhel70 rhel62" ;;
+    amzn-2023) distros="amazon2023" ;;
     amzn-*) distros="amazon2 $amazon1" ;;
 
     rhel-5*) distros="rhel55 rhel57" ;;


### PR DESCRIPTION
`m` doesn't download the correct binaries for Amazon Linux 2023. This is problematic since those binaries have been built to support `OpenSSL 3`. Instead, we fall back to the Amazon Linux 2 binaries, which support `OpenSSL 1` and therefore don't even run.