### PR TITLE
Use GitHub token from the environment for API requests if present

### DIFF
--- a/bin/m
+++ b/bin/m
@@ -439,6 +439,7 @@ get_all_tools_versions() {
 
   curl_tools_versions=(curl -sSf -H "Accept: application/vnd.github.v3+json")
   if [ -n "${GH_TOKEN:-}" ]; then
+    debug "Using GitHub token from environment for API requests"
     curl_tools_versions+=(-H "authorization: bearer ${GH_TOKEN:?}")
   fi
   curl_tools_versions+=("https://api.github.com/repos/mongodb/mongo-tools/git/refs/tags")

--- a/bin/m
+++ b/bin/m
@@ -437,11 +437,15 @@ get_all_tools_versions() {
     local rc_regex="(-rc[0-9]+)?"
   fi
 
-  tools_versions=`curl -sSf \
-  -H "Accept: application/vnd.github.v3+json" \
-  https://api.github.com/repos/mongodb/mongo-tools/git/refs/tags \
+  curl_tools_versions=(curl -sSf -H "Accept: application/vnd.github.v3+json")
+  if [ -n "${GH_TOKEN:-}" ]; then
+    curl_tools_versions+=(-H "authorization: bearer ${GH_TOKEN:?}")
+  fi
+  curl_tools_versions+=("https://api.github.com/repos/mongodb/mongo-tools/git/refs/tags")
+
+  tools_versions="$("${curl_tools_versions[@]}" \
   | sed -nE "s/^.*\"ref\"\: \"refs\/tags\/r?([[:digit:]]{2,3}\.[[:digit:]]+\.[[:digit:]]+)\",$/\1/p" \
-  | sort -V`
+  | sort -V)"
 
   get_all_versions
 

--- a/bin/m
+++ b/bin/m
@@ -437,7 +437,7 @@ get_all_tools_versions() {
     local rc_regex="(-rc[0-9]+)?"
   fi
 
-  tools_versions=`curl -s \
+  tools_versions=`curl -sSf \
   -H "Accept: application/vnd.github.v3+json" \
   https://api.github.com/repos/mongodb/mongo-tools/git/refs/tags \
   | sed -nE "s/^.*\"ref\"\: \"refs\/tags\/r?([[:digit:]]{2,3}\.[[:digit:]]+\.[[:digit:]]+)\",$/\1/p" \

--- a/bin/m
+++ b/bin/m
@@ -107,7 +107,7 @@ GET=
 which wget >/dev/null 2>&1 && GET="wget -q -O-"
 
 # curl support
-which curl >/dev/null 2>&1 && GET="curl -s -L"
+which curl >/dev/null 2>&1 && GET="curl -s -S -L"
 
 # Ensure we have curl or wget
 
@@ -208,7 +208,7 @@ get_all_versions() {
 
     if [ -z "$all_versions" ]; then
       debug "get_all_versions(): $GET $src_url"
-      all_versions=`$GET 2> /dev/null $src_url`
+      all_versions=`$GET $src_url`
       if [ $CACHE ]; then
         debug "Creating cache: $CACHE_SRC"
         echo "$all_versions" > $CACHE_SRC

--- a/bin/m
+++ b/bin/m
@@ -107,7 +107,7 @@ GET=
 which wget >/dev/null 2>&1 && GET="wget -q -O-"
 
 # curl support
-which curl >/dev/null 2>&1 && GET="curl -s -S -L"
+which curl >/dev/null 2>&1 && GET="curl -sSLf"
 
 # Ensure we have curl or wget
 


### PR DESCRIPTION
This should prevent invocations of m from getting rate limited on GitHub rest api when accessing the tags API for public repos anonymously.

In the process of troubleshooting this, I allow curl errors to bubble up to the terminal to help troubleshoot.

I'm not handling wget right now because curl is more common so will be preferred also because wget's -nv option still prints a basic success message. Also--curl is still used unconditionally for getting tags of mongodb/mongo-tools, so it's effectively required.