### PR TITLE
allow ubuntu 24 to fetch mongodb versions links provided for ubuntu 18

### DIFF
--- a/bin/m
+++ b/bin/m
@@ -984,7 +984,7 @@ get_distro_and_arch() {
     ubuntu-18*) distros="ubuntu1804 ubuntu1604" ;;
     ubuntu-20*) distros="ubuntu2004 ubuntu1804" ;;
     ubuntu-22*) distros="ubuntu2204 ubuntu2004 ubuntu1804" ;; # see #156
-    ubuntu-24*) distros="ubuntu2404 ubuntu2204 ubuntu2004" ;;
+    ubuntu-24*) distros="ubuntu2404 ubuntu2204 ubuntu2004 ubuntu1804" ;;
     ubuntu-*)   distros="ubuntu2404 ubuntu2204 ubuntu2004" ;;
 
     linuxmint-17*) distros="ubuntu1404" ;;


### PR DESCRIPTION
Hello,

I was trying to install the 4.2 mongo version through m on a ubuntu24 distribution, but the version isn't available, for the same reason as https://github.com/aheckmann/m/commit/fc480fcdcede9203ebc7199fc6ce4048db22a7ad (unfortunately, ubuntu20 oldest version listed is 4.4).

Not sure every install will work (assuming https://github.com/aheckmann/m/issues/93#issuecomment-1770242354)

